### PR TITLE
Add dominance feature

### DIFF
--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -959,6 +959,7 @@ impl IRapierCollisionObject for RapierArea {
         Material::new(
             self.base.get_collision_layer(),
             self.base.get_collision_mask(),
+            self.base.get_dominance(),
         )
     }
 

--- a/src/bodies/rapier_body.rs
+++ b/src/bodies/rapier_body.rs
@@ -1496,12 +1496,26 @@ impl RapierBody {
                     physics_engine.body_update_material(space_handle, body_handle, &mat);
                 }
             }
+            RapierBodyParam::Dominance => {
+                if p_value.get_type() != VariantType::INT {
+                    return;
+                }
+                self.base
+                    .set_dominance(variant_to_int(&p_value) as i8, physics_engine);
+                let mat = self.init_material();
+                let body_handle = self.base.get_body_handle();
+                let space_handle = self.base.get_space_id();
+                if self.base.is_valid() {
+                    physics_engine.body_update_material(space_handle, body_handle, &mat);
+                }
+            }
         }
     }
 
     pub fn get_extra_param(&self, p_param: RapierBodyParam) -> Variant {
         match p_param {
             RapierBodyParam::ContactSkin => self.contact_skin.to_variant(),
+            RapierBodyParam::Dominance => self.base.get_dominance().to_variant(),
         }
     }
 
@@ -2241,6 +2255,7 @@ impl IRapierCollisionObject for RapierBody {
             contact_skin: Some(self.contact_skin),
             collision_layer: Some(self.base.get_collision_layer()),
             collision_mask: Some(self.base.get_collision_mask()),
+            dominance: Some(self.base.get_dominance()),
         }
     }
 

--- a/src/bodies/rapier_collision_object_base.rs
+++ b/src/bodies/rapier_collision_object_base.rs
@@ -87,6 +87,7 @@ pub struct RapierCollisionObjectBase {
     pickable: bool,
     collision_mask: u32,
     collision_layer: u32,
+    dominance: i8,
     pub(crate) is_debugging_contacts: bool,
     pub(crate) mode: BodyMode,
     pub(crate) activation_angular_threshold: real,
@@ -137,6 +138,7 @@ impl RapierCollisionObjectBase {
             pickable: true,
             collision_mask: 1,
             collision_layer: 1,
+            dominance: 0,
             is_debugging_contacts: false,
             mode,
             activation_angular_threshold,
@@ -495,7 +497,7 @@ impl RapierCollisionObjectBase {
     pub fn set_collision_mask(&mut self, p_mask: u32, physics_engine: &mut PhysicsEngine) {
         self.collision_mask = p_mask;
         if self.is_valid() {
-            let material = Material::new(self.collision_layer, self.collision_mask);
+            let material = Material::new(self.collision_layer, self.collision_mask, self.dominance);
             physics_engine.body_update_material(
                 self.state.space_id,
                 self.state.body_handle,
@@ -511,7 +513,7 @@ impl RapierCollisionObjectBase {
     pub fn set_collision_layer(&mut self, p_layer: u32, physics_engine: &mut PhysicsEngine) {
         self.collision_layer = p_layer;
         if self.is_valid() {
-            let material = Material::new(self.collision_layer, self.collision_mask);
+            let material = Material::new(self.collision_layer, self.collision_mask, self.dominance);
             physics_engine.body_update_material(
                 self.state.space_id,
                 self.state.body_handle,
@@ -522,6 +524,22 @@ impl RapierCollisionObjectBase {
 
     pub fn get_collision_layer(&self) -> u32 {
         self.collision_layer
+    }
+
+    pub fn set_dominance(&mut self, dominance: i8, physics_engine: &mut PhysicsEngine) {
+        self.dominance = dominance;
+        if self.is_valid() {
+            let material = Material::new(self.collision_layer, self.collision_mask, self.dominance);
+            physics_engine.body_update_material(
+                self.state.space_id,
+                self.state.body_handle,
+                &material,
+            );
+        }
+    }
+
+    pub fn get_dominance(&self) -> i8 {
+        self.dominance
     }
 
     pub fn get_mode(&self) -> BodyMode {

--- a/src/rapier_wrapper/body.rs
+++ b/src/rapier_wrapper/body.rs
@@ -285,6 +285,9 @@ impl PhysicsEngine {
                     }
                 }
             }
+            if let Some(dominance) = mat.dominance {
+                body.set_dominance_group(dominance);
+            }
             body.wake_up(true);
         }
         self.body_wake_up_connected_rigidbodies(world_handle, body_handle);

--- a/src/rapier_wrapper/collider.rs
+++ b/src/rapier_wrapper/collider.rs
@@ -191,15 +191,17 @@ pub struct Material {
     pub contact_skin: Option<Real>,
     pub collision_mask: Option<u32>,
     pub collision_layer: Option<u32>,
+    pub dominance: Option<i8>,
 }
 impl Material {
-    pub fn new(collision_layer: u32, collision_mask: u32) -> Material {
+    pub fn new(collision_layer: u32, collision_mask: u32, dominance: i8) -> Material {
         Material {
             friction: None,
             restitution: None,
             contact_skin: None,
             collision_layer: Some(collision_layer),
             collision_mask: Some(collision_mask),
+            dominance: Some(dominance),
         }
     }
 }

--- a/src/servers/rapier_physics_server_extra.rs
+++ b/src/servers/rapier_physics_server_extra.rs
@@ -9,11 +9,13 @@ use crate::servers::RapierPhysicsServer;
 use crate::types::*;
 pub enum RapierBodyParam {
     ContactSkin,
+    Dominance,
 }
 impl RapierBodyParam {
     fn from_i32(value: i32) -> RapierBodyParam {
         match value {
             0 => RapierBodyParam::ContactSkin,
+            1 => RapierBodyParam::Dominance,
             _ => RapierBodyParam::ContactSkin,
         }
     }
@@ -22,6 +24,8 @@ impl RapierBodyParam {
 impl RapierPhysicsServer {
     #[func]
     /// Set an extra parameter for a body.
+    /// If [param param] is [code]0[/code], sets the body's contact skin value.
+    /// If [param param] is [code]1[/code], sets the body's dominance value.
     fn body_set_extra_param(body: Rid, param: i32, value: Variant) {
         let physics_data = physics_data();
         if let Some(body) = physics_data.collision_objects.get_mut(&body) {
@@ -37,6 +41,8 @@ impl RapierPhysicsServer {
 
     #[func]
     /// Get an extra parameter for a body.
+    /// If [param param] is [code]0[/code], gets the body's contact skin value.
+    /// If [param param] is [code]1[/code], gets the body's dominance value.
     fn body_get_extra_param(body: Rid, param: i32) -> Variant {
         let physics_data = physics_data();
         if let Some(body) = physics_data.collision_objects.get(&body) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,3 +148,9 @@ pub fn variant_to_float(variant: &Variant) -> real {
         _ => 0.0,
     }
 }
+pub fn variant_to_int(variant: &Variant) -> i32 {
+    match variant.get_type() {
+        VariantType::INT => variant.to::<i32>(),
+        _ => 0,
+    }
+}


### PR DESCRIPTION
This commit adds support for asymmetric collision using the dominance feature (https://rapier.rs/docs/user_guides/templates/rigid_body_dominance/).

To use this feature, simply call body_set_extra_param(<body rid>, 1, <dominance value>) from RapierPhysicsServer2D/3D

Examples (dominance from left to the right: -1, 0, 1):

https://github.com/user-attachments/assets/19938e37-c4c9-4d9a-8aa2-485bd7b7ead5

https://github.com/user-attachments/assets/e63205ba-803e-4fbf-8632-d82aac709d0f



Project: [dominance.zip](https://github.com/user-attachments/files/22266953/dominance.zip)