### PR TITLE
Fix: Android 16KB page alignment for Play Store compliance

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,15 +11,25 @@ rustflags = [
   "-C", "link-args=-sDISABLE_EXCEPTION_CATCHING=1",
   "-Z", "link-native-libraries=no",
 ]
+
 [target.armv7-linux-androideabi]
 linker = "armv7a-linux-androideabi23-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
 [target.aarch64-linux-android]
 linker = "aarch64-linux-android23-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
 [target.x86_64-linux-android]
 linker = "x86_64-linux-android23-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
 [target.i686-linux-android]
 linker = "i686-linux-android23-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"


### PR DESCRIPTION
This PR adds the required linker flags to ensure all Android builds of Rapier use 16KB page alignment, in compliance with Google Play’s new Android 15+ requirements (effective November 2025).

Details

Updated .cargo/config.toml to include -Wl,-z,max-page-size=16384 for all Android targets:

armv7-linux-androideabi
aarch64-linux-android
x86_64-linux-android
i686-linux-android

Verification

Verified using zipalign -c -v -P 16 4 → All libraries passed.

Fixes build issues for Android 15+ devices with 16KB page size.

Related issue

Fixes #390
