### PR TITLE
Implements a fix to allow setting ConcavePolygonShape2Ds with empty point data

### DIFF
--- a/src/rapier_wrapper/shape.rs
+++ b/src/rapier_wrapper/shape.rs
@@ -242,7 +242,7 @@ impl PhysicsEngine {
         indices: Option<Vec<[u32; 2]>>,
         handle: ShapeHandle,
     ) {
-        if points.len() == 0 {
+        if points.is_empty() {
             self.remove_shape(handle);
             return;
         }


### PR DESCRIPTION
Currently, if Rapier updates a ConcavePolygonShape2D with an empty point array (via shape_set_data), the broadphase and narrowphase collision checks will start to throw out-of-bounds errors. This operation doesn't yield errors if performed in Godot's native physics, so to achieve parity it should be fixed.

This PR fixes the issue by removing the shape if its updated data has no points. If the shape then experiences other update operations which do contain valid (non-zero) point arrays, the shape will be re-inserted into the physics world with its new points. Please note, I haven't yet checked how Godot's physics actually handles this situation-- there may be a more graceful solution.