### PR TITLE
Stationary shapecast detection fix

### DIFF
--- a/src/rapier_wrapper/shape.rs
+++ b/src/rapier_wrapper/shape.rs
@@ -242,6 +242,10 @@ impl PhysicsEngine {
         indices: Option<Vec<[u32; 2]>>,
         handle: ShapeHandle,
     ) {
+        if points.is_empty() {
+            self.remove_shape(handle);
+            return;
+        }
         let points_vec = point_array_to_vec(points);
         let shape = SharedShape::polyline(points_vec, indices);
         self.insert_shape(shape, handle);


### PR DESCRIPTION
Fixes a bug where shapecasts were never returning 'true', as the 'collided' state of the returned collision result wasn't being set. 

NOTE: I've noticed while debugging this that the normals returned by the shapecast seem to be backwards (eg (0,1) when they should be (0,-1)). However, I think this might be on the Parry side...