### PR TITLE
fixes backwards normals on shapecasts

### DIFF
--- a/src/spaces/rapier_direct_space_state_impl.rs
+++ b/src/spaces/rapier_direct_space_state_impl.rs
@@ -427,7 +427,7 @@ impl RapierDirectSpaceStateImpl {
             } else {
                 r_info.linear_velocity = Vector::default();
             }
-            r_info.normal = vector_to_godot(result.normal1);
+            r_info.normal = vector_to_godot(result.normal2);
             r_info.rid = rid;
             r_info.shape = shape_index as i32;
             r_info.point = vector_to_godot(result.pixel_witness1);


### PR DESCRIPTION
The contact result defines normal1 as the normal pointing _away_ from shape 1.
Therefore, as shape 1 here is the shapecast, we want to take normal2 from the contact result instead of normal1.

Fixes and closes https://github.com/appsinacup/godot-rapier-physics/issues/396 