### PR TITLE
Remove "shape not found!" error

### DIFF
--- a/src/rapier_wrapper/shape.rs
+++ b/src/rapier_wrapper/shape.rs
@@ -293,7 +293,6 @@ impl PhysicsEngine {
         if let Some(shape) = self.get_shape(handle) {
             return shape.compute_local_aabb();
         }
-        godot_error!("Shape not found");
         rapier::prelude::Aabb::new_invalid()
     }
 


### PR DESCRIPTION
Removes an error report that complained when the user tried to fetch the AABB of a shape handle with no collision shapes assigned to it. As shape handles without collision shapes can be perfectly valid, this error report is a bit misleading.