### PR TITLE
disable custom api for local builds.

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Build
       shell: sh
       run: |
-        cargo build --target=${{ inputs.arch }} --release --features="${{ inputs.features }}" ${{ inputs.extra_flags}} --no-default-features
+        cargo build --target=${{ inputs.arch }} --release --features="${{ inputs.features }},api-custom" ${{ inputs.extra_flags }} --no-default-features
     - name: Copy to release
       shell: sh
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dim2 = []
 dim3 = []
 single = []
 double = ["godot/double-precision"]
+api-custom = ["godot/api-custom"]
 enhanced-determinism = ["rapier2d/enhanced-determinism", "rapier2d-f64/enhanced-determinism", "rapier3d/enhanced-determinism", "rapier3d-f64/enhanced-determinism"]
 serde-serialize = ["serde", "hashbrown/serde", "bincode", "serde_json", "godot/serde", "rapier2d/serde-serialize", "rapier2d-f64/serde-serialize", "rapier3d/serde-serialize", "rapier3d-f64/serde-serialize" ]
 # Note: SIMD disabled for f64 builds due to upstream rapier bugs with f64 SIMD implementation
@@ -40,7 +41,6 @@ double-dim3 = ["double", "dim3", "rapier3d-f64", "salva3d-f64"]
 bincode = { version = "1", optional = true }
 hashbrown = { version = "0.14" }
 
-#godot = { git = "https://github.com/Ughuuu/gdext", branch = "disable-layout-tests", features=["register-docs"] }
 godot = { version = "0.4.0", features=["register-docs"] }
 
 rapier2d = { git = "https://github.com/ughuuu/rapier", branch = "custom-changes-v29", optional = true }
@@ -75,4 +75,4 @@ codegen-units = 1
 opt-level = 1
 
 [package.metadata.docs.rs]
-license-file = "../LICENSE"
+license-file = "LICENSE"


### PR DESCRIPTION
Ideally we shouldn't need this. Also, since this issue exists: https://github.com/appsinacup/godot-rapier-physics/issues/388 we aren't able to build on all platforms anyway. So reverting back to default builds from gdext.
It will also simplify the build process locally. Actually for local dev i might keep it disabled, but for ci/cd it is needed for more obscure android arch.