### PR TITLE
fix character bodies not using excepted bodies

### DIFF
--- a/src/spaces/rapier_space_body_helper.rs
+++ b/src/spaces/rapier_space_body_helper.rs
@@ -320,7 +320,11 @@ impl RapierSpace {
                             physics_collision_objects.get(&shape_col_object)
                             && let Some(collision_body) = shape_col_object.get_body()
                         {
-                            if collision_body.has_exception(p_body.get_base().get_rid()) {
+                            let moving_rid = p_body.get_base().get_rid();
+                            let col_rid = collision_body.get_base().get_rid();
+                            if collision_body.has_exception(moving_rid)
+                                || p_body.has_exception(col_rid)
+                            {
                                 continue;
                             }
                             if let Some(col_shape) = physics_shapes.get(
@@ -537,7 +541,10 @@ impl RapierSpace {
                     if let Some(shape_col_object) = physics_collision_objects.get(&shape_col_object)
                         && let Some(collision_body) = shape_col_object.get_body()
                     {
-                        if collision_body.has_exception(p_body.get_base().get_rid()) {
+                        let moving_rid = p_body.get_base().get_rid();
+                        let col_rid = collision_body.get_base().get_rid();
+                        if collision_body.has_exception(moving_rid) || p_body.has_exception(col_rid)
+                        {
                             continue;
                         }
                         if let Some(col_shape) = physics_shapes.get(
@@ -787,7 +794,10 @@ impl RapierSpace {
                     if let Some(shape_col_object) = physics_collision_objects.get(&shape_col_object)
                         && let Some(collision_body) = shape_col_object.get_body()
                     {
-                        if collision_body.has_exception(p_body.get_base().get_rid()) {
+                        let moving_rid = p_body.get_base().get_rid();
+                        let col_rid = collision_body.get_base().get_rid();
+                        if collision_body.has_exception(moving_rid) || p_body.has_exception(col_rid)
+                        {
                             continue;
                         }
                         let col_shape_rid = collision_body


### PR DESCRIPTION
- Fixes https://github.com/appsinacup/godot-rapier-physics/issues/355

Issue was it was not checking both ways (eg A excludes B and B excludes A) and it was not doing in all 3 places of the character collision checking.