### PR TITLE
Fix: Generic6DOFJoint does not allow for translation only rotation

### DIFF
--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -509,7 +509,7 @@ impl PhysicsEngine {
             // Extract the X axis from the rotation as UnitVector
             let axis1_vec = axis_1 * Vector::x_axis();
             let axis2_vec = axis_2 * Vector::x_axis();
-            let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
+            let joint = GenericJointBuilder::new(JointAxesMask::FREE_FIXED_AXES)
                 .local_anchor1(Point { coords: anchor_1 })
                 .local_anchor2(Point { coords: anchor_2 })
                 .local_axis1(axis1_vec)


### PR DESCRIPTION
While testing the new Generic6DOF joint implementation I noticed the joint not working as expected. After some digging around in the code I noticed that the locked axis is shared with the cone twist joint, which seemed off. I rebuilt it with the all axis being unlocked and it seems to work now.

Also sorry for being able to implement this last time I worked on the repo.