### PR TITLE
Fix center of mass not being used correctly for forces applied at points

### DIFF
--- a/src/rapier_wrapper/body.rs
+++ b/src/rapier_wrapper/body.rs
@@ -578,7 +578,7 @@ impl PhysicsEngine {
                 .get_mut(body_handle)
         {
             let mut local_point = Point { coords: point };
-            local_point += body.center_of_mass().coords;
+            local_point += body.position().translation.vector;
             body.apply_impulse_at_point(impulse, local_point, true);
         }
         self.body_wake_up_connected_rigidbodies(world_handle, body_handle);


### PR DESCRIPTION
Resolves #358

The center of mass position was being added to the point the force was being applied to, which caused objects to always behave as if their center of mass was their position. This has been changed to instead use the object's position, which now yields the expected result.

I have only tested this in 2D, but I expect that this fix should also work in 3D (being as simple as it is).