### PR TITLE
Fix body material defaulting some state

### DIFF
--- a/src/bodies/rapier_body.rs
+++ b/src/bodies/rapier_body.rs
@@ -1358,6 +1358,7 @@ impl RapierBody {
                     self.base.get_space_id(),
                     self.base.get_body_handle(),
                     &mat,
+                    false,
                 );
             }
             BodyParameter::MASS => {
@@ -1569,7 +1570,7 @@ impl RapierBody {
                 let body_handle = self.base.get_body_handle();
                 let space_handle = self.base.get_space_id();
                 if self.base.is_valid() {
-                    physics_engine.body_update_material(space_handle, body_handle, &mat);
+                    physics_engine.body_update_material(space_handle, body_handle, &mat, false);
                 }
             }
             RapierBodyParam::Dominance => {
@@ -1582,7 +1583,7 @@ impl RapierBody {
                 let body_handle = self.base.get_body_handle();
                 let space_handle = self.base.get_space_id();
                 if self.base.is_valid() {
-                    physics_engine.body_update_material(space_handle, body_handle, &mat);
+                    physics_engine.body_update_material(space_handle, body_handle, &mat, false);
                 }
             }
             RapierBodyParam::SoftCcd => {
@@ -1596,7 +1597,7 @@ impl RapierBody {
                 let body_handle = self.base.get_body_handle();
                 let space_handle = self.base.get_space_id();
                 if self.base.is_valid() {
-                    physics_engine.body_update_material(space_handle, body_handle, &mat);
+                    physics_engine.body_update_material(space_handle, body_handle, &mat, false);
                 }
             }
             RapierBodyParam::Massless => {
@@ -2145,6 +2146,7 @@ impl RapierBody {
                     self.base.get_space_id(),
                     self.base.get_body_handle(),
                     &self.init_material(),
+                    false,
                 );
             }
         }

--- a/src/bodies/rapier_collision_object_base.rs
+++ b/src/bodies/rapier_collision_object_base.rs
@@ -500,6 +500,7 @@ impl RapierCollisionObjectBase {
                 self.state.space_id,
                 self.state.body_handle,
                 &material,
+                true,
             );
         }
     }
@@ -516,6 +517,7 @@ impl RapierCollisionObjectBase {
                 self.state.space_id,
                 self.state.body_handle,
                 &material,
+                true,
             );
         }
     }
@@ -532,6 +534,7 @@ impl RapierCollisionObjectBase {
                 self.state.space_id,
                 self.state.body_handle,
                 &material,
+                true,
             );
         }
     }

--- a/src/rapier_wrapper/body.rs
+++ b/src/rapier_wrapper/body.rs
@@ -253,6 +253,7 @@ impl PhysicsEngine {
         world_handle: WorldHandle,
         body_handle: RigidBodyHandle,
         mat: &Material,
+        base_only: bool,
     ) {
         if let Some(physics_world) = self.get_mut_world(world_handle)
             && let Some(body) = physics_world
@@ -266,8 +267,10 @@ impl PhysicsEngine {
                     .collider_set
                     .get_mut(*collider)
                 {
-                    col.set_friction(mat.friction);
-                    col.set_restitution(mat.restitution);
+                    if !base_only {
+                        col.set_friction(mat.friction);
+                        col.set_restitution(mat.restitution);
+                    }
                     if let Some(coupling_boundary_entry) =
                         physics_world.fluids_pipeline.coupling.entries.get(collider)
                         && let Some(coupling_boundary) = physics_world
@@ -282,7 +285,9 @@ impl PhysicsEngine {
                                 filter: mat.collision_mask.into(),
                             };
                     }
-                    col.set_contact_skin(mat.contact_skin);
+                    if !base_only {
+                        col.set_contact_skin(mat.contact_skin);
+                    }
                     col.set_collision_groups(InteractionGroups {
                         memberships: Group::from(mat.collision_layer),
                         filter: Group::from(mat.collision_mask),
@@ -290,7 +295,9 @@ impl PhysicsEngine {
                     });
                 }
             }
-            body.set_soft_ccd_prediction(mat.soft_ccd);
+            if !base_only {
+                body.set_soft_ccd_prediction(mat.soft_ccd);
+            }
             body.set_dominance_group(mat.dominance);
             body.wake_up(true);
         }


### PR DESCRIPTION
Resolves #492
Resolves #488

This prevents RapierCollisionObjectBase from overwriting material properties that should only be set by RapierBody. Namely bounce and friction, but also contact skin and soft ccd.

I just threw this together because I realized it would be simple to fix this way, but if this seems too hacky I can set up a system where `body_update_material` takes two material parameters: a new `BaseMaterial` and the standard `Material`, where they each handle their respective collision object type, and the `Material` is optional to allow `RapierCollisionObjectBase` to modify things safely.