### PR TITLE
Fix area2D monitorable preventing monitoring

### DIFF
--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -279,8 +279,7 @@ impl RapierArea {
         // If the other object is an area:
         if let Some(other_collider) = other_collider
             && let Some(other_area) = other_collider.get_mut_area()
-            && (self.area_monitor_callback.is_none()
-                || !other_area.is_monitorable())
+            && (self.area_monitor_callback.is_none() || !other_area.is_monitorable())
         {
             return;
         }

--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -280,7 +280,6 @@ impl RapierArea {
         if let Some(other_collider) = other_collider
             && let Some(other_area) = other_collider.get_mut_area()
             && (self.area_monitor_callback.is_none()
-                || !self.is_monitorable()
                 || !other_area.is_monitorable())
         {
             return;


### PR DESCRIPTION
Area2D shouldn't care whether it is monitorable or not when checking with an other
This fixes #https://github.com/appsinacup/godot-rapier-physics/issues/514



https://github.com/user-attachments/assets/902dba6f-53d2-49f5-9517-3e0b6db9529b


